### PR TITLE
Update dockcheck.sh

### DIFF
--- a/app/dockcheck.sh
+++ b/app/dockcheck.sh
@@ -16,7 +16,7 @@ IFS=',' read -r -a Excludes <<< "$Exclude" ; unset IFS
 SearchName="$1"
 
 for i in $(docker ps --filter "name=$SearchName" --format '{{.Names}}') ; do
- [[ " ${Excludes[*]} " =~ ${i} ]] && continue; # Skip if the container is excluded
+ for e in "${Excludes[@]}" ; do [[ "$i" == "$e" ]] && continue 2 ; done # Skip if the container is excluded
  printf ". "
  RepoUrl=$(docker inspect "$i" --format='{{.Config.Image}}')
  LocalHash=$(docker image inspect "$RepoUrl" --format '{{.RepoDigests}}')


### PR DESCRIPTION
Fixes to the "Exclude"-logic, to only exclude exact matches.